### PR TITLE
fix: skip AppImage for Linux ARM64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,8 @@ jobs:
             rust_targets: ''
           - name: linux-arm64
             platform: ubuntu-22.04
-            args: --target aarch64-unknown-linux-gnu
+            # Only build .deb for ARM64 (AppImage fails on cross-compile due to exec format error)
+            args: --target aarch64-unknown-linux-gnu --bundles deb
             rust_targets: aarch64-unknown-linux-gnu
           - name: windows-x64
             platform: windows-latest
@@ -158,7 +159,7 @@ jobs:
             | Windows | x64 | `.msi` or `.exe` |
             | Windows | ARM64 | `.exe` |
             | Linux | x64 | `.deb` or `.AppImage` |
-            | Linux | ARM64 | `.deb` or `.AppImage` |
+            | Linux | ARM64 | `.deb` |
 
             ---
             **macOS users**: Run `xattr -cr "/Applications/DDEV Manager.app"` if blocked by Gatekeeper.


### PR DESCRIPTION
## Summary
- Skip AppImage bundling for Linux ARM64 builds (only build `.deb`)
- AppImage fails on cross-compile with "Exec format error" because the bundler tries to execute ARM64 binaries on an x86_64 runner
- Update release notes table to reflect ARM64 Linux only has `.deb`

## Test plan
- [x] Re-run the release workflow to verify ARM64 Linux builds successfully