### PR TITLE
fix: only restart project when changing versions if it was running

### DIFF
--- a/src/components/projects/NodejsVersionSelector.tsx
+++ b/src/components/projects/NodejsVersionSelector.tsx
@@ -19,6 +19,7 @@ interface NodejsVersionSelectorProps {
   currentVersion: string | null | undefined;
   projectName: string;
   approot: string;
+  isRunning: boolean;
   disabled?: boolean;
 }
 
@@ -26,6 +27,7 @@ export function NodejsVersionSelector({
   currentVersion,
   projectName,
   approot,
+  isRunning,
   disabled = false,
 }: NodejsVersionSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -115,8 +117,9 @@ export function NodejsVersionSelector({
       name: projectName,
       approot,
       nodejsVersion: selectedVersion,
+      restart: isRunning,
     });
-  }, [selectedVersion, projectName, approot, changeNodejsVersion]);
+  }, [selectedVersion, projectName, approot, isRunning, changeNodejsVersion]);
 
   const handleCancel = useCallback(() => {
     setShowConfirm(false);
@@ -184,10 +187,14 @@ export function NodejsVersionSelector({
       <ConfirmDialog
         isOpen={showConfirm}
         title="Change Node.js Version"
-        message={`Change Node.js version to ${selectedVersion}? The project will be restarted.`}
+        message={
+          isRunning
+            ? `Change Node.js version to ${selectedVersion}? The project will be restarted.`
+            : `Change Node.js version to ${selectedVersion}?`
+        }
         confirmLabel="Change"
         cancelLabel="Cancel"
-        variant="warning"
+        variant={isRunning ? "warning" : "default"}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
       />

--- a/src/components/projects/PhpVersionSelector.tsx
+++ b/src/components/projects/PhpVersionSelector.tsx
@@ -19,6 +19,7 @@ interface PhpVersionSelectorProps {
   currentVersion: string | null | undefined;
   projectName: string;
   approot: string;
+  isRunning: boolean;
   disabled?: boolean;
 }
 
@@ -26,6 +27,7 @@ export function PhpVersionSelector({
   currentVersion,
   projectName,
   approot,
+  isRunning,
   disabled = false,
 }: PhpVersionSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -115,8 +117,9 @@ export function PhpVersionSelector({
       name: projectName,
       approot,
       phpVersion: selectedVersion,
+      restart: isRunning,
     });
-  }, [selectedVersion, projectName, approot, changePhpVersion]);
+  }, [selectedVersion, projectName, approot, isRunning, changePhpVersion]);
 
   const handleCancel = useCallback(() => {
     setShowConfirm(false);
@@ -184,10 +187,14 @@ export function PhpVersionSelector({
       <ConfirmDialog
         isOpen={showConfirm}
         title="Change PHP Version"
-        message={`Change PHP version to ${selectedVersion}? The project will be restarted.`}
+        message={
+          isRunning
+            ? `Change PHP version to ${selectedVersion}? The project will be restarted.`
+            : `Change PHP version to ${selectedVersion}?`
+        }
         confirmLabel="Change"
         cancelLabel="Cancel"
-        variant="warning"
+        variant={isRunning ? "warning" : "default"}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
       />

--- a/src/components/projects/ProjectDetails.tsx
+++ b/src/components/projects/ProjectDetails.tsx
@@ -295,6 +295,7 @@ export function ProjectDetails() {
                 currentVersion={project.php_version}
                 projectName={project.name}
                 approot={project.approot}
+                isRunning={isRunning}
                 disabled={isOperationPending}
               />{" "}
               •{" "}
@@ -302,6 +303,7 @@ export function ProjectDetails() {
                 currentVersion={project.nodejs_version}
                 projectName={project.name}
                 approot={project.approot}
+                isRunning={isRunning}
                 disabled={isOperationPending}
               />
             </p>

--- a/src/hooks/useDdev.ts
+++ b/src/hooks/useDdev.ts
@@ -323,13 +323,15 @@ export function useChangePhpVersion() {
       name,
       approot,
       phpVersion,
+      restart,
     }: {
       name: string;
       approot: string;
       phpVersion: string;
+      restart: boolean;
     }) => {
-      if (autoOpen) open();
-      return invoke<string>("change_php_version", { name, approot, phpVersion });
+      if (autoOpen && restart) open();
+      return invoke<string>("change_php_version", { name, approot, phpVersion, restart });
     },
     onSuccess: () => {
       // Invalidate after a short delay to allow the command to complete
@@ -350,13 +352,15 @@ export function useChangeNodejsVersion() {
       name,
       approot,
       nodejsVersion,
+      restart,
     }: {
       name: string;
       approot: string;
       nodejsVersion: string;
+      restart: boolean;
     }) => {
-      if (autoOpen) open();
-      return invoke<string>("change_nodejs_version", { name, approot, nodejsVersion });
+      if (autoOpen && restart) open();
+      return invoke<string>("change_nodejs_version", { name, approot, nodejsVersion, restart });
     },
     onSuccess: () => {
       // Invalidate after a short delay to allow the command to complete


### PR DESCRIPTION
## Summary
- PHP and Node.js version changes no longer force a restart if the project is stopped
- Only running projects will be restarted after version change
- Confirmation dialog message and variant updated based on project state:
  - Running: "... The project will be restarted." (warning variant)
  - Stopped: "Change X version to Y?" (default variant)

## Changes
- Backend: Added `restart` parameter to `change_php_version` and `change_nodejs_version` commands
- Frontend: Pass `isRunning` to version selector components
- UI: Conditional confirmation message and dialog variant

## Test plan
- [ ] Change PHP version on a stopped project - should not restart
- [ ] Change PHP version on a running project - should restart
- [ ] Same for Node.js version changes