### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- Describe what this PR does and why. Link to related issue(s) if applicable. -->
+
+Fixes #
+
+## Changes
+
+<!-- List the main changes in bullet points -->
+
+-
+
+## Screenshots
+
+<!-- For UI changes, add before/after screenshots or a short video -->
+
+## Test plan
+
+<!-- Describe how you tested these changes -->
+
+- [ ]
+
+## Checklist
+
+- [ ] Tests pass locally (`pnpm test:run`)
+- [ ] New code has tests (if applicable)
+- [ ] Documentation updated (if applicable)
+- [ ] Commit messages follow [conventions](./CONTRIBUTING.md#commit-messages)
+- [ ] No unrelated changes included


### PR DESCRIPTION
## Summary

Adds a PR template to standardize pull request submissions based on the CONTRIBUTING.md guidelines.

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` with:
  - Summary section with issue linking
  - Changes bullet list
  - Screenshots section for UI changes
  - Test plan checklist
  - PR checklist (tests, docs, conventions)