### PR TITLE
feat: add high contrast dark theme for accessibility

### DIFF
--- a/src-tauri/src/commands/utils.rs
+++ b/src-tauri/src/commands/utils.rs
@@ -104,6 +104,7 @@ pub fn sync_theme_menu(app_handle: tauri::AppHandle, theme: String) -> Result<()
         if let Ok(items) = items.lock() {
             let _ = items.light.set_checked(theme == "light");
             let _ = items.dark.set_checked(theme == "dark");
+            let _ = items.high_contrast.set_checked(theme == "high-contrast");
             let _ = items.system.set_checked(theme == "system");
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::Manager;
 pub struct ThemeMenuItems {
     pub light: CheckMenuItem<tauri::Wry>,
     pub dark: CheckMenuItem<tauri::Wry>,
+    pub high_contrast: CheckMenuItem<tauri::Wry>,
     pub system: CheckMenuItem<tauri::Wry>,
 }
 
@@ -48,7 +49,7 @@ pub fn run() {
 
             // Build the View menu with zoom controls and appearance
             let zoom_in = MenuItemBuilder::with_id("zoom_in", "Zoom In")
-                .accelerator("CmdOrCtrl++")
+                .accelerator("CmdOrCtrl+Plus")
                 .build(app)?;
             let zoom_out = MenuItemBuilder::with_id("zoom_out", "Zoom Out")
                 .accelerator("CmdOrCtrl+-")
@@ -60,6 +61,8 @@ pub fn run() {
             // Appearance submenu with check items (default to System checked)
             let theme_light = CheckMenuItemBuilder::with_id("theme_light", "Light").build(app)?;
             let theme_dark = CheckMenuItemBuilder::with_id("theme_dark", "Dark").build(app)?;
+            let theme_high_contrast =
+                CheckMenuItemBuilder::with_id("theme_high_contrast", "High Contrast").build(app)?;
             let theme_system = CheckMenuItemBuilder::with_id("theme_system", "System")
                 .checked(true)
                 .build(app)?;
@@ -68,12 +71,14 @@ pub fn run() {
             app.manage(Mutex::new(ThemeMenuItems {
                 light: theme_light.clone(),
                 dark: theme_dark.clone(),
+                high_contrast: theme_high_contrast.clone(),
                 system: theme_system.clone(),
             }));
 
             let appearance_menu = SubmenuBuilder::new(app, "Appearance")
                 .item(&theme_light)
                 .item(&theme_dark)
+                .item(&theme_high_contrast)
                 .item(&theme_system)
                 .build()?;
 
@@ -106,6 +111,9 @@ pub fn run() {
                     if let Ok(items) = items.lock() {
                         let _ = items.light.set_checked(event_id == "theme_light");
                         let _ = items.dark.set_checked(event_id == "theme_dark");
+                        let _ = items
+                            .high_contrast
+                            .set_checked(event_id == "theme_high_contrast");
                         let _ = items.system.set_checked(event_id == "theme_system");
                     }
                 }
@@ -119,6 +127,9 @@ pub fn run() {
                     "zoom_reset" => Some("if(window.__ZOOM_RESET)window.__ZOOM_RESET()"),
                     "theme_light" => Some("if(window.__SET_THEME)window.__SET_THEME('light')"),
                     "theme_dark" => Some("if(window.__SET_THEME)window.__SET_THEME('dark')"),
+                    "theme_high_contrast" => {
+                        Some("if(window.__SET_THEME)window.__SET_THEME('high-contrast')")
+                    }
                     "theme_system" => Some("if(window.__SET_THEME)window.__SET_THEME('system')"),
                     _ => None,
                 };

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,16 @@
 import { useState, useEffect } from "react";
-import { X, Sun, Moon, Monitor, Minus, Plus, RefreshCw, Download, RotateCcw } from "lucide-react";
+import {
+  X,
+  Sun,
+  Moon,
+  Monitor,
+  Contrast,
+  Minus,
+  Plus,
+  RefreshCw,
+  Download,
+  RotateCcw,
+} from "lucide-react";
 import { useAppStore } from "@/stores/appStore";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
@@ -32,9 +43,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       .catch(() => setAppVersion("dev"));
   }, []);
 
-  const themeOptions: { value: "light" | "dark" | "system"; icon: typeof Sun; label: string }[] = [
+  const themeOptions: {
+    value: "light" | "dark" | "high-contrast" | "system";
+    icon: typeof Sun;
+    label: string;
+  }[] = [
     { value: "light", icon: Sun, label: "Light" },
     { value: "dark", icon: Moon, label: "Dark" },
+    { value: "high-contrast", icon: Contrast, label: "High Contrast" },
     { value: "system", icon: Monitor, label: "System" },
   ];
 

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -37,6 +37,7 @@ describe("useTheme", () => {
 
     // Clear document classes and styles
     document.documentElement.classList.remove("dark");
+    document.documentElement.classList.remove("high-contrast");
     document.documentElement.style.colorScheme = "";
     document.documentElement.style.removeProperty("--zoom");
   });
@@ -84,6 +85,30 @@ describe("useTheme", () => {
       expect(document.documentElement.classList.contains("dark")).toBe(true);
       expect(document.documentElement.style.colorScheme).toBe("dark");
     });
+
+    it("should apply high-contrast theme with both dark and high-contrast classes", () => {
+      useAppStore.setState({ theme: "high-contrast" });
+
+      renderHook(() => useTheme());
+
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.classList.contains("high-contrast")).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe("dark");
+    });
+
+    it("should remove high-contrast class when switching to other themes", () => {
+      useAppStore.setState({ theme: "high-contrast" });
+
+      const { rerender } = renderHook(() => useTheme());
+
+      expect(document.documentElement.classList.contains("high-contrast")).toBe(true);
+
+      useAppStore.setState({ theme: "dark" });
+      rerender();
+
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.classList.contains("high-contrast")).toBe(false);
+    });
   });
 
   describe("system theme listener", () => {
@@ -108,6 +133,14 @@ describe("useTheme", () => {
 
     it("should not add event listener when theme is dark", () => {
       useAppStore.setState({ theme: "dark" });
+
+      renderHook(() => useTheme());
+
+      expect(mockMediaQueryList.addEventListener).not.toHaveBeenCalled();
+    });
+
+    it("should not add event listener when theme is high-contrast", () => {
+      useAppStore.setState({ theme: "high-contrast" });
 
       renderHook(() => useTheme());
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -18,8 +18,9 @@ export function useTheme() {
     const applyTheme = () => {
       // Determine if we should use dark mode
       let isDark = false;
+      const isHighContrast = theme === "high-contrast";
 
-      if (theme === "dark") {
+      if (theme === "dark" || theme === "high-contrast") {
         isDark = true;
       } else if (theme === "system") {
         isDark = mediaQuery.matches;
@@ -31,6 +32,13 @@ export function useTheme() {
         root.classList.add("dark");
       } else {
         root.classList.remove("dark");
+      }
+
+      // Apply or remove high-contrast class
+      if (isHighContrast) {
+        root.classList.add("high-contrast");
+      } else {
+        root.classList.remove("high-contrast");
       }
 
       // Also set color-scheme for native elements (scrollbars, form controls)

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,9 @@
 /* Enable class-based dark mode for manual theme switching */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Enable high contrast mode variant */
+@custom-variant high-contrast (&:where(.high-contrast, .high-contrast *));
+
 @theme {
   --font-sans:
     "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -30,6 +33,15 @@
   --color-sidebar: oklch(0.97 0.01 250);
   --color-sidebar-dark: oklch(0.15 0.02 250);
 
+  /* High contrast palette */
+  --color-hc-bg: #000000;
+  --color-hc-text: #ffffff;
+  --color-hc-accent: #00ffff;
+  --color-hc-accent-alt: #ffff00;
+  --color-hc-success: #00ff00;
+  --color-hc-error: #ff0000;
+  --color-hc-border: #ffffff;
+
   /* Border radius */
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
@@ -55,6 +67,58 @@ body {
 html.dark body {
   background-color: var(--color-gray-950);
   color: var(--color-gray-100);
+}
+
+/* High contrast mode - class-based (always dark-based) */
+html.high-contrast body {
+  background-color: var(--color-hc-bg);
+  color: var(--color-hc-text);
+}
+
+/* High contrast overrides for common elements */
+html.high-contrast {
+  /* Override white to black for backgrounds */
+  --color-white: #000000;
+
+  /* Links and primary elements - bright cyan */
+  --color-primary-50: #000000;
+  --color-primary-100: #001a1a;
+  --color-primary-200: #003333;
+  --color-primary-300: #00cccc;
+  --color-primary-400: #00ffff;
+  --color-primary-500: #00ffff;
+  --color-primary-600: #00ffff;
+  --color-primary-700: #00ffff;
+  --color-primary-800: #00ffff;
+  --color-primary-900: #001a1a;
+  --color-primary-950: #000000;
+
+  /* Status colors - maximum brightness */
+  --color-success: #00ff00;
+  --color-warning: #ffff00;
+  --color-error: #ff3333;
+
+  /* Sidebar */
+  --color-sidebar: #000000;
+  --color-sidebar-dark: #000000;
+
+  /*
+   * Gray palette for high contrast dark mode:
+   * - Dark grays (700-950) used for backgrounds in dark mode → pure black
+   * - Light grays (100-300) used for text in dark mode → pure white
+   * - Mid grays (400-600) used for secondary text/borders → bright for visibility
+   */
+  --color-gray-50: #000000;
+  --color-gray-100: #ffffff;
+  --color-gray-200: #ffffff;
+  --color-gray-300: #ffffff;
+  --color-gray-400: #ffffff;
+  --color-gray-500: #cccccc;
+  --color-gray-600: #ffffff;
+  --color-gray-700: #222222;
+  --color-gray-800: #000000;
+  --color-gray-900: #000000;
+  --color-gray-950: #000000;
 }
 
 /* Prevent text selection on UI elements */
@@ -89,6 +153,87 @@ html.dark ::-webkit-scrollbar-thumb {
 
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: var(--color-gray-600);
+}
+
+/* High contrast scrollbar */
+html.high-contrast ::-webkit-scrollbar-thumb {
+  background: var(--color-hc-accent);
+}
+
+html.high-contrast ::-webkit-scrollbar-thumb:hover {
+  background: var(--color-hc-text);
+}
+
+/* High contrast - ensure borders are visible */
+html.high-contrast *:where([class*="border"]) {
+  border-color: #ffffff !important;
+}
+
+/* High contrast - buttons and interactive elements */
+html.high-contrast button,
+html.high-contrast [role="button"] {
+  border: 2px solid #ffffff !important;
+}
+
+html.high-contrast button:hover,
+html.high-contrast [role="button"]:hover {
+  background-color: #333333 !important;
+}
+
+html.high-contrast button:focus,
+html.high-contrast [role="button"]:focus {
+  outline: 3px solid #00ffff !important;
+  outline-offset: 2px !important;
+}
+
+/* High contrast - inputs */
+html.high-contrast input,
+html.high-contrast select,
+html.high-contrast textarea {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+  border: 2px solid #ffffff !important;
+}
+
+html.high-contrast input:focus,
+html.high-contrast select:focus,
+html.high-contrast textarea:focus {
+  outline: 3px solid #00ffff !important;
+  outline-offset: 2px !important;
+}
+
+/* High contrast - range slider */
+html.high-contrast input[type="range"] {
+  background-color: #333333 !important;
+}
+
+html.high-contrast input[type="range"]::-webkit-slider-thumb {
+  background-color: #00ffff !important;
+  border: 2px solid #ffffff !important;
+}
+
+/* High contrast - selected/active states */
+html.high-contrast [aria-selected="true"],
+html.high-contrast [aria-checked="true"],
+html.high-contrast [data-state="checked"] {
+  background-color: #003333 !important;
+  border-color: #00ffff !important;
+}
+
+/* High contrast - links */
+html.high-contrast a {
+  color: #00ffff !important;
+  text-decoration: underline !important;
+}
+
+html.high-contrast a:hover {
+  color: #ffff00 !important;
+}
+
+/* High contrast - focus visible */
+html.high-contrast *:focus-visible {
+  outline: 3px solid #00ffff !important;
+  outline-offset: 2px !important;
 }
 
 /* Progress bar animation */

--- a/src/lib/shortcuts/index.test.ts
+++ b/src/lib/shortcuts/index.test.ts
@@ -19,10 +19,10 @@ describe("DEFAULT_SHORTCUTS", () => {
   });
 
   describe("zoom shortcuts", () => {
-    it("should have zoom-in shortcut (Cmd/Ctrl + =)", () => {
+    it("should have zoom-in shortcut (Cmd/Ctrl + +)", () => {
       const shortcut = DEFAULT_SHORTCUTS.find((s) => s.id === "zoom-in");
       expect(shortcut).toBeDefined();
-      expect(shortcut?.key).toBe("=");
+      expect(shortcut?.key).toBe("+");
       expect(shortcut?.modifierKey).toBe(true);
     });
 
@@ -97,9 +97,9 @@ describe("zoom shortcuts in registry", () => {
     shortcutRegistry.clear();
   });
 
-  it("should find zoom-in with Cmd + =", () => {
+  it("should find zoom-in with Cmd + +", () => {
     const event = new KeyboardEvent("keydown", {
-      key: "=",
+      key: "+",
       metaKey: true,
     });
     const found = shortcutRegistry.findByKey(event);

--- a/src/lib/shortcuts/index.ts
+++ b/src/lib/shortcuts/index.ts
@@ -14,10 +14,10 @@ const ZOOM_STEP = 10;
  * These are registered when initializeDefaultShortcuts() is called.
  */
 export const DEFAULT_SHORTCUTS: KeyboardShortcut[] = [
-  // Zoom in: Cmd/Ctrl + =
+  // Zoom in: Cmd/Ctrl + Plus (handled by native menu, this is fallback)
   {
     id: "zoom-in",
-    key: "=",
+    key: "+",
     modifierKey: true,
     description: "Zoom in",
     action: () => {
@@ -73,7 +73,7 @@ declare global {
     __ZOOM_IN?: () => void;
     __ZOOM_OUT?: () => void;
     __ZOOM_RESET?: () => void;
-    __SET_THEME?: (theme: "light" | "dark" | "system") => void;
+    __SET_THEME?: (theme: "light" | "dark" | "high-contrast" | "system") => void;
   }
 }
 
@@ -96,7 +96,7 @@ export function initializeMenuZoomHandlers(): void {
     useAppStore.getState().setZoom(100);
   };
 
-  window.__SET_THEME = (theme: "light" | "dark" | "system") => {
+  window.__SET_THEME = (theme: "light" | "dark" | "high-contrast" | "system") => {
     useAppStore.getState().setTheme(theme);
   };
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -21,8 +21,8 @@ interface AppState {
   toggleSidebar: () => void;
 
   // Theme
-  theme: "light" | "dark" | "system";
-  setTheme: (theme: "light" | "dark" | "system") => void;
+  theme: "light" | "dark" | "high-contrast" | "system";
+  setTheme: (theme: "light" | "dark" | "high-contrast" | "system") => void;
 
   // Zoom (percentage: 50-200)
   zoom: number;


### PR DESCRIPTION
## Summary

- Add High Contrast theme option for accessibility, featuring:
  - Pure black background (#000000) with pure white text (#FFFFFF)
  - Bright cyan (#00FFFF) accents for links and interactive elements
  - High-visibility white borders on all interactive elements
  - Bold focus states with cyan outlines
- Add theme option in Settings modal and View > Appearance menu
- Fix zoom-in keyboard shortcut (Cmd++) to work across different keyboard layouts

## Test plan

- [ ] Open Settings and verify High Contrast theme option appears
- [ ] Select High Contrast and verify:
  - [ ] Background is pure black
  - [ ] Text is white and clearly visible
  - [ ] Buttons have visible white borders
  - [ ] Focus states show cyan outlines
- [ ] Verify View > Appearance > High Contrast menu item works
- [ ] Verify theme syncs between Settings and menu checkmarks
- [ ] Verify theme persists after app restart
- [ ] Test Cmd++ (zoom in) keyboard shortcut works
- [ ] Verify other themes (Light, Dark, System) still work correctly