### PR TITLE
feat: add custom tooltip component with accessibility improvements

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { SettingsModal } from "@/components/settings/SettingsModal";
 import { CreateProjectWizard } from "@/components/projects/CreateProjectWizard";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
+import { Tooltip } from "@/components/ui/Tooltip";
 
 function DdevLogo({
   className,
@@ -100,30 +101,34 @@ export function Header() {
           New Project
         </Button>
 
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={handleRefresh}
-          icon={<RefreshCw className="h-4 w-4" aria-hidden="true" />}
-          aria-label="Refresh projects"
-        />
+        <Tooltip content="Refresh projects">
+          <Button variant="ghost" size="icon" onClick={handleRefresh} aria-label="Refresh projects">
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </Tooltip>
 
-        <Button
-          variant={runningCount > 0 ? "danger" : "ghost"}
-          size="icon"
-          onClick={handlePoweroff}
-          disabled={runningCount === 0 || poweroff.isPending}
-          icon={<Power className="h-4 w-4" aria-hidden="true" />}
-          aria-label="Power off all projects"
-        />
+        <Tooltip content="Power off all projects">
+          <Button
+            variant={runningCount > 0 ? "danger" : "ghost"}
+            size="icon"
+            onClick={handlePoweroff}
+            disabled={runningCount === 0 || poweroff.isPending}
+            aria-label="Power off all projects"
+          >
+            <Power className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </Tooltip>
 
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setIsSettingsOpen(true)}
-          icon={<Settings className="h-4 w-4" aria-hidden="true" />}
-          aria-label="Settings"
-        />
+        <Tooltip content="Settings">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setIsSettingsOpen(true)}
+            aria-label="Settings"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </Tooltip>
       </div>
 
       <SettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { Loader2, X, Terminal, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useStatusStore } from "@/stores/statusStore";
+import { Tooltip } from "@/components/ui/Tooltip";
 
 interface CommandOutput {
   line: string;
@@ -109,23 +110,24 @@ export function StatusBar({ onToggleTerminal, isTerminalOpen }: StatusBarProps) 
 
       <div className="flex items-center gap-3 px-4 py-1.5">
         {/* Output toggle button */}
-        <button
-          onClick={onToggleTerminal}
-          className={cn(
-            "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors",
-            isTerminalOpen
-              ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400"
-              : "text-gray-600 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
-          )}
-          title={isTerminalOpen ? "Hide output" : "Show output"}
-        >
-          {isTerminalOpen ? (
-            <Terminal className="h-3.5 w-3.5" />
-          ) : (
-            <ChevronUp className="h-3.5 w-3.5" />
-          )}
-          Output
-        </button>
+        <Tooltip content={isTerminalOpen ? "Hide output" : "Show output"}>
+          <button
+            onClick={onToggleTerminal}
+            className={cn(
+              "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+              isTerminalOpen
+                ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400"
+                : "text-gray-600 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+            )}
+          >
+            {isTerminalOpen ? (
+              <Terminal className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronUp className="h-3.5 w-3.5" />
+            )}
+            Output
+          </button>
+        </Tooltip>
 
         {/* Separator */}
         <div className="h-4 w-px bg-gray-300 dark:bg-gray-600" />
@@ -154,14 +156,15 @@ export function StatusBar({ onToggleTerminal, isTerminalOpen }: StatusBarProps) 
 
             {/* Cancel button */}
             {processId && !exiting && (
-              <button
-                onClick={handleCancel}
-                className="flex shrink-0 items-center gap-1.5 rounded-md bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
-                title="Cancel command"
-              >
-                <X className="h-3.5 w-3.5" />
-                Cancel
-              </button>
+              <Tooltip content="Cancel command">
+                <button
+                  onClick={handleCancel}
+                  className="flex shrink-0 items-center gap-1.5 rounded-md bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Cancel
+                </button>
+              </Tooltip>
             )}
           </>
         ) : (

--- a/src/components/projects/EnvironmentTab.test.tsx
+++ b/src/components/projects/EnvironmentTab.test.tsx
@@ -42,7 +42,7 @@ describe("EnvironmentTab", () => {
 
       render(<EnvironmentTab {...defaultProps} />);
 
-      const copyButtons = screen.getAllByTitle("Copy URL");
+      const copyButtons = screen.getAllByLabelText("Copy URL");
       await user.click(copyButtons[0]);
 
       expect(writeText).toHaveBeenCalledWith(defaultProps.project.primary_url);
@@ -54,7 +54,7 @@ describe("EnvironmentTab", () => {
       const user = userEvent.setup();
       render(<EnvironmentTab {...defaultProps} />);
 
-      const openButtons = screen.getAllByTitle("Open URL");
+      const openButtons = screen.getAllByLabelText("Open URL");
       await user.click(openButtons[0]);
 
       await waitFor(() => {
@@ -68,7 +68,7 @@ describe("EnvironmentTab", () => {
       const user = userEvent.setup();
       render(<EnvironmentTab {...defaultProps} />);
 
-      const urlButton = screen.getByTitle("Open in browser");
+      const urlButton = screen.getByLabelText("Open in browser");
       await user.click(urlButton);
 
       await waitFor(() => {
@@ -81,14 +81,14 @@ describe("EnvironmentTab", () => {
     it("should not show open URL button when project is stopped", () => {
       render(<EnvironmentTab {...defaultProps} isRunning={false} />);
 
-      expect(screen.queryByTitle("Open URL")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Open URL")).not.toBeInTheDocument();
     });
 
     it("should show URL as non-clickable text when project is stopped", () => {
       render(<EnvironmentTab {...defaultProps} isRunning={false} />);
 
       // URL should be shown as code element, not button
-      expect(screen.queryByTitle("Open in browser")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Open in browser")).not.toBeInTheDocument();
       expect(screen.getByText(defaultProps.project.primary_url)).toBeInTheDocument();
     });
 
@@ -147,7 +147,7 @@ describe("EnvironmentTab", () => {
 
       render(<EnvironmentTab {...defaultProps} />);
 
-      await user.click(screen.getByTitle("Copy password"));
+      await user.click(screen.getByLabelText("Copy password"));
 
       expect(writeText).toHaveBeenCalledWith("db");
 
@@ -252,7 +252,7 @@ describe("EnvironmentTab", () => {
       const user = userEvent.setup();
       render(<EnvironmentTab {...defaultProps} />);
 
-      await user.click(screen.getByTitle("Open folder"));
+      await user.click(screen.getByLabelText("Open folder"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("open_project_folder", {

--- a/src/components/projects/EnvironmentTab.tsx
+++ b/src/components/projects/EnvironmentTab.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { useOpenUrl, useOpenFolder } from "@/hooks/useDdev";
 import { ProjectScreenshot } from "./ProjectScreenshot";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { Accordion } from "@/components/ui/Accordion";
 import { cn } from "@/lib/utils";
 import type { DdevProjectDetails } from "@/types/ddev";
@@ -145,17 +146,19 @@ export function EnvironmentTab({
                     <span className="text-gray-900 dark:text-gray-100">
                       {project.dbinfo.password}
                     </span>
-                    <button
-                      onClick={() => copyToClipboard(project.dbinfo!.password, "password")}
-                      className="rounded p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
-                      title="Copy password"
-                    >
-                      {copiedField === "password" ? (
-                        <Check className="h-3 w-3 text-green-500" />
-                      ) : (
-                        <Copy className="h-3 w-3 text-gray-400" />
-                      )}
-                    </button>
+                    <Tooltip content="Copy password">
+                      <button
+                        onClick={() => copyToClipboard(project.dbinfo!.password, "password")}
+                        className="rounded p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+                        aria-label="Copy password"
+                      >
+                        {copiedField === "password" ? (
+                          <Check className="h-3 w-3 text-green-500" />
+                        ) : (
+                          <Copy className="h-3 w-3 text-gray-400" />
+                        )}
+                      </button>
+                    </Tooltip>
                   </div>
                 </div>
                 {isRunning && project.dbinfo.published_port > 0 && (
@@ -213,20 +216,25 @@ export function EnvironmentTab({
         <section>
           <h3 className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">Services</h3>
           <div className="grid grid-cols-2 gap-2">
-            {Object.entries(project.services).map(([name, service]) => (
-              <div
-                key={name}
-                className="flex items-center gap-2 rounded-lg bg-gray-50 p-2 dark:bg-gray-900"
-              >
+            {Object.entries(project.services).map(([name, service]) => {
+              const statusLabel = service.status.charAt(0).toUpperCase() + service.status.slice(1);
+              return (
                 <div
-                  className={cn(
-                    "h-2 w-2 rounded-full",
-                    service.status === "running" ? "bg-green-500" : "bg-gray-400"
-                  )}
-                />
-                <span className="text-sm text-gray-700 dark:text-gray-300">{name}</span>
-              </div>
-            ))}
+                  key={name}
+                  className="flex items-center gap-2 rounded-lg bg-gray-50 p-2 dark:bg-gray-900"
+                >
+                  <Tooltip content={statusLabel} position="right">
+                    <div
+                      className={cn(
+                        "h-2 w-2 rounded-full",
+                        service.status === "running" ? "bg-green-500" : "bg-gray-400"
+                      )}
+                    />
+                  </Tooltip>
+                  <span className="text-sm text-gray-700 dark:text-gray-300">{name}</span>
+                </div>
+              );
+            })}
           </div>
         </section>
       )}
@@ -238,13 +246,15 @@ export function EnvironmentTab({
           <code className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300">
             {project.approot}
           </code>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => openFolder.mutate(project.approot)}
-            icon={<Folder className="h-4 w-4 text-gray-500" />}
-            title="Open folder"
-          />
+          <Tooltip content="Open folder">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => openFolder.mutate(project.approot)}
+              icon={<Folder className="h-4 w-4 text-gray-500" />}
+              aria-label="Open folder"
+            />
+          </Tooltip>
         </div>
       </section>
 
@@ -294,38 +304,46 @@ function UrlRow({
     <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-2 dark:bg-gray-900">
       <span className="w-16 text-xs text-gray-500">{label}</span>
       {isActive ? (
-        <button
-          onClick={() => openUrl.mutate(url)}
-          className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 flex-1 cursor-pointer truncate text-left font-mono text-sm underline decoration-dotted underline-offset-2"
-          title="Open in browser"
-        >
-          {url}
-        </button>
+        <div className="min-w-0 flex-1">
+          <Tooltip content="Open in browser">
+            <button
+              onClick={() => openUrl.mutate(url)}
+              className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 w-full cursor-pointer truncate text-left font-mono text-sm underline decoration-dotted underline-offset-2"
+              aria-label="Open in browser"
+            >
+              {url}
+            </button>
+          </Tooltip>
+        </div>
       ) : (
         <code className="flex-1 truncate text-sm text-gray-400 dark:text-gray-500">{url}</code>
       )}
       {isActive && (
+        <Tooltip content="Open URL">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => openUrl.mutate(url)}
+            icon={<ExternalLink className="h-4 w-4 text-gray-400" />}
+            aria-label="Open URL"
+          />
+        </Tooltip>
+      )}
+      <Tooltip content="Copy URL">
         <Button
           variant="ghost"
           size="icon-sm"
-          onClick={() => openUrl.mutate(url)}
-          icon={<ExternalLink className="h-4 w-4 text-gray-400" />}
-          title="Open URL"
+          onClick={onCopy}
+          icon={
+            copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4 text-gray-400" />
+            )
+          }
+          aria-label="Copy URL"
         />
-      )}
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={onCopy}
-        icon={
-          copied ? (
-            <Check className="h-4 w-4 text-green-500" />
-          ) : (
-            <Copy className="h-4 w-4 text-gray-400" />
-          )
-        }
-        title="Copy URL"
-      />
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/projects/ProjectCard.test.tsx
+++ b/src/components/projects/ProjectCard.test.tsx
@@ -78,9 +78,9 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      expect(screen.getByTitle("Stop")).toBeInTheDocument();
-      expect(screen.getByTitle("Restart")).toBeInTheDocument();
-      expect(screen.getByTitle("Open in browser")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByLabelText("Restart")).toBeInTheDocument();
+      expect(screen.getByLabelText("Open in browser")).toBeInTheDocument();
     });
 
     it("should call stop_project when stop button clicked", async () => {
@@ -92,7 +92,7 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      await user.click(screen.getByTitle("Stop"));
+      await user.click(screen.getByLabelText("Stop"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("stop_project", {
@@ -110,7 +110,7 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      await user.click(screen.getByTitle("Restart"));
+      await user.click(screen.getByLabelText("Restart"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("restart_project", {
@@ -128,7 +128,7 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      await user.click(screen.getByTitle("Open in browser"));
+      await user.click(screen.getByLabelText("Open in browser"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("open_project_url", {
@@ -144,8 +144,8 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      expect(screen.getByTitle("Start")).toBeInTheDocument();
-      expect(screen.getByTitle("Open folder")).toBeInTheDocument();
+      expect(screen.getByLabelText("Start")).toBeInTheDocument();
+      expect(screen.getByLabelText("Open folder")).toBeInTheDocument();
     });
 
     it("should call start_project when start button clicked", async () => {
@@ -157,7 +157,7 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      await user.click(screen.getByTitle("Start"));
+      await user.click(screen.getByLabelText("Start"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("start_project", {
@@ -175,7 +175,7 @@ describe("ProjectCard", () => {
 
       render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-      await user.click(screen.getByTitle("Open folder"));
+      await user.click(screen.getByLabelText("Open folder"));
 
       await waitFor(() => {
         expect(invoke).toHaveBeenCalledWith("open_project_folder", {
@@ -191,7 +191,7 @@ describe("ProjectCard", () => {
 
     render(<ProjectCard project={project} isSelected={false} onSelect={mockOnSelect} />);
 
-    await user.click(screen.getByTitle("Start"));
+    await user.click(screen.getByLabelText("Start"));
 
     // onSelect should not be called because the event propagation is stopped
     expect(mockOnSelect).not.toHaveBeenCalled();

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from "react";
 import { Play, Square, RotateCw, ExternalLink, Folder } from "lucide-react";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { ProjectTypeIcon, getProjectTypeColor } from "./ProjectTypeIcon";
 import { cn, getStatusBgColor, formatProjectType, truncatePath } from "@/lib/utils";
 import {
@@ -74,10 +75,12 @@ export const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function
     >
       {/* Title row with status, name, and actions */}
       <div className="flex items-center gap-2">
-        <div
-          className={cn("h-2.5 w-2.5 shrink-0 rounded-full", getStatusBgColor(project.status))}
-          aria-hidden="true"
-        />
+        <Tooltip content={statusLabel} position="right">
+          <div
+            className={cn("h-2.5 w-2.5 shrink-0 rounded-full", getStatusBgColor(project.status))}
+            aria-hidden="true"
+          />
+        </Tooltip>
         <span className="sr-only">Status: {statusLabel}</span>
         <h3 className="min-w-0 flex-1 truncate font-medium text-gray-900 dark:text-gray-100">
           {project.name}
@@ -87,64 +90,75 @@ export const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function
           {isRunning ? (
             <>
               {project.primary_url && (
+                <Tooltip content="Open in browser">
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    tabIndex={-1}
+                    onClick={handleOpenUrl}
+                    className="rounded-md"
+                    aria-label="Open in browser"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Button>
+                </Tooltip>
+              )}
+              <Tooltip content="Restart">
                 <Button
                   variant="ghost"
                   size="icon-sm"
                   tabIndex={-1}
-                  onClick={handleOpenUrl}
-                  icon={<ExternalLink className="h-3.5 w-3.5" />}
-                  title="Open in browser"
-                  className="rounded-md"
-                />
-              )}
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                tabIndex={-1}
-                onClick={handleRestart}
-                disabled={isPending}
-                icon={
+                  onClick={handleRestart}
+                  disabled={isPending}
+                  className="rounded-md text-yellow-600 hover:bg-yellow-100 dark:text-yellow-400 dark:hover:bg-yellow-900/30"
+                  aria-label="Restart"
+                >
                   <RotateCw
                     className={cn("h-3.5 w-3.5", restartProject.isPending && "animate-spin")}
                   />
-                }
-                title="Restart"
-                className="rounded-md text-yellow-600 hover:bg-yellow-100 dark:text-yellow-400 dark:hover:bg-yellow-900/30"
-              />
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                tabIndex={-1}
-                onClick={handleStop}
-                disabled={isPending}
-                icon={<Square className="h-3.5 w-3.5" />}
-                title="Stop"
-                className="rounded-md text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-900/30"
-              />
+                </Button>
+              </Tooltip>
+              <Tooltip content="Stop">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  tabIndex={-1}
+                  onClick={handleStop}
+                  disabled={isPending}
+                  className="rounded-md text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-900/30"
+                  aria-label="Stop"
+                >
+                  <Square className="h-3.5 w-3.5" />
+                </Button>
+              </Tooltip>
             </>
           ) : (
             <>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                tabIndex={-1}
-                onClick={handleOpenFolder}
-                icon={<Folder className="h-3.5 w-3.5" />}
-                title="Open folder"
-                className="rounded-md"
-              />
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                tabIndex={-1}
-                onClick={handleStart}
-                disabled={isPending}
-                icon={
+              <Tooltip content="Open folder">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  tabIndex={-1}
+                  onClick={handleOpenFolder}
+                  className="rounded-md"
+                  aria-label="Open folder"
+                >
+                  <Folder className="h-3.5 w-3.5" />
+                </Button>
+              </Tooltip>
+              <Tooltip content="Start">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  tabIndex={-1}
+                  onClick={handleStart}
+                  disabled={isPending}
+                  className="rounded-md text-green-600 hover:bg-green-100 dark:text-green-400 dark:hover:bg-green-900/30"
+                  aria-label="Start"
+                >
                   <Play className={cn("h-3.5 w-3.5", startProject.isPending && "animate-pulse")} />
-                }
-                title="Start"
-                className="rounded-md text-green-600 hover:bg-green-100 dark:text-green-400 dark:hover:bg-green-900/30"
-              />
+                </Button>
+              </Tooltip>
             </>
           )}
         </div>
@@ -160,12 +174,11 @@ export const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function
         />
         <span>{formatProjectType(project.type)}</span>
       </div>
-      <div
-        className="overflow-hidden text-xs whitespace-nowrap text-gray-400 dark:text-gray-500"
-        title={project.shortroot}
-      >
-        {truncatePath(project.shortroot, 43)}
-      </div>
+      <Tooltip content={project.shortroot} position="bottom">
+        <div className="overflow-hidden text-xs whitespace-nowrap text-gray-400 dark:text-gray-500">
+          {truncatePath(project.shortroot, 43)}
+        </div>
+      </Tooltip>
     </div>
   );
 });

--- a/src/components/projects/ProjectDetails.tsx
+++ b/src/components/projects/ProjectDetails.tsx
@@ -14,6 +14,7 @@ import {
   Database,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { Tabs, type Tab } from "@/components/ui/Tabs";
 import { listen } from "@tauri-apps/api/event";
 import { AddonsSection } from "@/components/addons/AddonsSection";
@@ -319,11 +320,18 @@ export function ProjectDetails() {
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
       <div className="border-b border-gray-200 p-4 dark:border-gray-800">
-        <div className="flex items-start justify-between">
-          <div>
+        <div className="flex items-start gap-4">
+          <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <div className={cn("h-3 w-3 rounded-full", getStatusBgColor(project.status))} />
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+              <Tooltip content={project.status.charAt(0).toUpperCase() + project.status.slice(1)}>
+                <div
+                  className={cn(
+                    "h-3 w-3 flex-shrink-0 rounded-full",
+                    getStatusBgColor(project.status)
+                  )}
+                />
+              </Tooltip>
+              <h2 className="truncate text-xl font-semibold text-gray-900 dark:text-gray-100">
                 {project.name}
               </h2>
             </div>
@@ -353,7 +361,47 @@ export function ProjectDetails() {
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center gap-2">
+          <div className="flex flex-shrink-0 items-center gap-1">
+            {/* Quick actions - icon only with tooltips */}
+            {isRunning && project.primary_url && (
+              <Tooltip content="Open Site">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => openUrl.mutate(project.primary_url)}
+                  aria-label="Open Site"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip content="Open Folder">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => openFolder.mutate(project.approot)}
+                aria-label="Open Folder"
+              >
+                <Folder className="h-4 w-4" />
+              </Button>
+            </Tooltip>
+            {isRunning && project.mailpit_https_url && (
+              <Tooltip content="Mailpit">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => openUrl.mutate(project.mailpit_https_url)}
+                  aria-label="Mailpit"
+                >
+                  <Mail className="h-4 w-4" />
+                </Button>
+              </Tooltip>
+            )}
+
+            {/* Divider */}
+            <div className="mx-1 h-6 w-px bg-gray-300 dark:bg-gray-700" />
+
+            {/* Start/Stop/Restart buttons */}
             {isRunning ? (
               <>
                 <Button
@@ -389,40 +437,6 @@ export function ProjectDetails() {
           </div>
         </div>
       </div>
-
-      {/* Quick Actions Bar */}
-      {isRunning && (
-        <div className="flex flex-wrap gap-2 border-b border-gray-200 bg-gray-50 px-4 py-6 dark:border-gray-800 dark:bg-gray-900/50">
-          {project.primary_url && (
-            <Button
-              variant="secondary"
-              onClick={() => openUrl.mutate(project.primary_url)}
-              icon={<ExternalLink className="h-4 w-4" />}
-              className="shadow-sm"
-            >
-              Open Site
-            </Button>
-          )}
-          <Button
-            variant="secondary"
-            onClick={() => openFolder.mutate(project.approot)}
-            icon={<Folder className="h-4 w-4" />}
-            className="shadow-sm"
-          >
-            Open Folder
-          </Button>
-          {project.mailpit_https_url && (
-            <Button
-              variant="secondary"
-              onClick={() => openUrl.mutate(project.mailpit_https_url)}
-              icon={<Mail className="h-4 w-4" />}
-              className="shadow-sm"
-            >
-              Mailpit
-            </Button>
-          )}
-        </div>
-      )}
 
       {/* Tab Bar */}
       <Tabs

--- a/src/components/projects/ProjectScreenshot.tsx
+++ b/src/components/projects/ProjectScreenshot.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { RefreshCw, ImageOff, Loader2, Camera } from "lucide-react";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { useScreenshotData, useCaptureScreenshot } from "@/hooks/useScreenshot";
 import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
@@ -132,13 +133,17 @@ export function ProjectScreenshot({ projectName, primaryUrl, isRunning }: Projec
           style={{ maxHeight: "300px" }}
         />
         {isRunning && (
-          <button
-            onClick={handleCapture}
-            className="absolute top-2 right-2 rounded-md bg-black/50 p-1.5 text-white hover:bg-black/70"
-            title="Refresh screenshot"
-          >
-            <RefreshCw className="h-4 w-4" />
-          </button>
+          <div className="absolute top-2 right-2">
+            <Tooltip content="Refresh screenshot">
+              <button
+                onClick={handleCapture}
+                className="rounded-md bg-black/50 p-1.5 text-white hover:bg-black/70"
+                aria-label="Refresh screenshot"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </button>
+            </Tooltip>
+          </div>
         )}
       </div>
     );

--- a/src/components/terminal/Terminal.test.tsx
+++ b/src/components/terminal/Terminal.test.tsx
@@ -32,7 +32,7 @@ describe("Terminal", () => {
     it("should have clear button", () => {
       render(<Terminal isOpen={true} />);
 
-      expect(screen.getByTitle("Clear output")).toBeInTheDocument();
+      expect(screen.getByLabelText("Clear output")).toBeInTheDocument();
     });
 
     it("should display command output lines", async () => {
@@ -103,7 +103,7 @@ describe("Terminal", () => {
 
       expect(screen.getByText("Some output")).toBeInTheDocument();
 
-      await user.click(screen.getByTitle("Clear output"));
+      await user.click(screen.getByLabelText("Clear output"));
 
       expect(screen.queryByText("Some output")).not.toBeInTheDocument();
       expect(screen.getByText("Command output will appear here...")).toBeInTheDocument();

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/Tooltip";
 
 interface CommandOutput {
   line: string;
@@ -107,13 +108,15 @@ export function Terminal({ isOpen }: TerminalProps) {
             </span>
           )}
         </div>
-        <button
-          onClick={clearLines}
-          className="rounded p-1.5 text-gray-400 hover:bg-gray-700 hover:text-gray-200"
-          title="Clear output"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
+        <Tooltip content="Clear output">
+          <button
+            onClick={clearLines}
+            className="rounded p-1.5 text-gray-400 hover:bg-gray-700 hover:text-gray-200"
+            aria-label="Clear output"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </Tooltip>
       </div>
 
       {/* Terminal content */}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,167 @@
+import { useState, useRef, useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+type Position = "top" | "bottom" | "left" | "right";
+
+interface TooltipProps {
+  content: string;
+  children: ReactNode;
+  /** Delay in ms before showing tooltip (default: 200) */
+  delay?: number;
+  /** Preferred position of tooltip (default: "top"). Will auto-flip if not enough space. */
+  position?: Position;
+}
+
+interface TooltipState {
+  isVisible: boolean;
+  x: number;
+  y: number;
+  actualPosition: Position;
+}
+
+const TOOLTIP_OFFSET = 8;
+const VIEWPORT_PADDING = 8;
+// Estimated tooltip dimensions for initial calculation
+const ESTIMATED_HEIGHT = 32;
+const ESTIMATED_WIDTH = 100;
+
+export function Tooltip({ content, children, delay = 200, position = "top" }: TooltipProps) {
+  const [state, setState] = useState<TooltipState>({
+    isVisible: false,
+    x: 0,
+    y: 0,
+    actualPosition: position,
+  });
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const calculatePosition = (
+    triggerRect: DOMRect,
+    preferredPosition: Position
+  ): { x: number; y: number; actualPosition: Position } => {
+    const viewport = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+
+    // Calculate available space in each direction
+    const spaceTop = triggerRect.top - VIEWPORT_PADDING;
+    const spaceBottom = viewport.height - triggerRect.bottom - VIEWPORT_PADDING;
+    const spaceLeft = triggerRect.left - VIEWPORT_PADDING;
+    const spaceRight = viewport.width - triggerRect.right - VIEWPORT_PADDING;
+
+    // Determine best position based on preferred position and available space
+    let finalPosition = preferredPosition;
+
+    if (preferredPosition === "top" && spaceTop < ESTIMATED_HEIGHT + TOOLTIP_OFFSET) {
+      finalPosition = "bottom";
+    } else if (preferredPosition === "bottom" && spaceBottom < ESTIMATED_HEIGHT + TOOLTIP_OFFSET) {
+      finalPosition = "top";
+    } else if (preferredPosition === "left" && spaceLeft < ESTIMATED_WIDTH + TOOLTIP_OFFSET) {
+      finalPosition = "right";
+    } else if (preferredPosition === "right" && spaceRight < ESTIMATED_WIDTH + TOOLTIP_OFFSET) {
+      finalPosition = "left";
+    }
+
+    // Calculate coordinates based on final position
+    let x = triggerRect.left + triggerRect.width / 2;
+    let y = triggerRect.top;
+
+    switch (finalPosition) {
+      case "bottom":
+        y = triggerRect.bottom + TOOLTIP_OFFSET;
+        break;
+      case "left":
+        x = triggerRect.left - TOOLTIP_OFFSET;
+        y = triggerRect.top + triggerRect.height / 2;
+        break;
+      case "right":
+        x = triggerRect.right + TOOLTIP_OFFSET;
+        y = triggerRect.top + triggerRect.height / 2;
+        break;
+      case "top":
+      default:
+        y = triggerRect.top - TOOLTIP_OFFSET;
+        break;
+    }
+
+    // Prevent horizontal overflow for top/bottom positions
+    if (finalPosition === "top" || finalPosition === "bottom") {
+      const halfWidth = ESTIMATED_WIDTH / 2;
+      if (x - halfWidth < VIEWPORT_PADDING) {
+        x = halfWidth + VIEWPORT_PADDING;
+      } else if (x + halfWidth > viewport.width - VIEWPORT_PADDING) {
+        x = viewport.width - halfWidth - VIEWPORT_PADDING;
+      }
+    }
+
+    return { x, y, actualPosition: finalPosition };
+  };
+
+  const showTooltip = () => {
+    timeoutRef.current = setTimeout(() => {
+      if (triggerRef.current) {
+        const triggerRect = triggerRef.current.getBoundingClientRect();
+        const { x, y, actualPosition } = calculatePosition(triggerRect, position);
+        setState({ isVisible: true, x, y, actualPosition });
+      }
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setState((prev) => ({ ...prev, isVisible: false }));
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClasses: Record<Position, string> = {
+    top: "-translate-x-1/2 -translate-y-full",
+    bottom: "-translate-x-1/2",
+    left: "-translate-x-full -translate-y-1/2",
+    right: "-translate-y-1/2",
+  };
+
+  return (
+    <>
+      <div
+        ref={triggerRef}
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
+        onFocus={showTooltip}
+        onBlur={hideTooltip}
+        className="inline-flex"
+      >
+        {children}
+      </div>
+      {state.isVisible &&
+        createPortal(
+          <div
+            role="tooltip"
+            className={cn(
+              "pointer-events-none fixed z-[100] rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium whitespace-nowrap text-white shadow-lg dark:bg-white dark:text-gray-900",
+              "animate-in fade-in-0 zoom-in-95 duration-100",
+              positionClasses[state.actualPosition]
+            )}
+            style={{
+              left: state.x,
+              top: state.y,
+            }}
+          >
+            {content}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Create new `Tooltip` component with auto-alignment to prevent viewport overflow
- Add tooltips throughout the app for better UX and accessibility:
  - Header buttons (Refresh, Power off, Settings)
  - ProjectCard (status indicator, quick actions, truncated path)
  - ProjectDetails header (Open Site, Open Folder, Mailpit)
  - EnvironmentTab (URL actions, database password copy, folder button, service status indicators)
  - StatusBar (Output toggle, Cancel button)
  - Terminal (Clear output button)
  - ProjectScreenshot (Refresh button)
- Replace `title` attributes with `aria-label` for better accessibility
- Tooltip features: 200ms delay, high contrast (black/white), auto-flip when near viewport edges

## Test plan
- [x] All 406 tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Verify tooltips appear on hover with correct positioning
- [ ] Verify tooltips auto-flip when near viewport edges
- [ ] Verify tooltips work in both light and dark themes