### PR TITLE
fix: prevent URL text from overlapping action buttons

### DIFF
--- a/src/components/projects/EnvironmentTab.tsx
+++ b/src/components/projects/EnvironmentTab.tsx
@@ -304,11 +304,11 @@ function UrlRow({
     <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-2 dark:bg-gray-900">
       <span className="w-16 text-xs text-gray-500">{label}</span>
       {isActive ? (
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 overflow-hidden">
           <Tooltip content="Open in browser">
             <button
               onClick={() => openUrl.mutate(url)}
-              className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 w-full cursor-pointer truncate text-left font-mono text-sm underline decoration-dotted underline-offset-2"
+              className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 block max-w-full cursor-pointer truncate text-left font-mono text-sm underline decoration-dotted underline-offset-2"
               aria-label="Open in browser"
             >
               {url}


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to the URL text container
- Change button to use `block max-w-full` for proper truncation

Fixes #30

## Test plan
- [x] All 406 tests pass
- [x] Verify URL text truncates properly with ellipsis
- [x] Verify action buttons remain visible and clickable