### PR TITLE
feat: add issue management workflow for release-based closing

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,117 @@
+name: Issue Management
+
+on:
+  pull_request:
+    types: [closed]
+  release:
+    types: [published]
+
+jobs:
+  # When a PR is merged, add "pending-release" label to linked issues
+  label-linked-issues:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Add pending-release label to linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+
+            // Match patterns like "Fixes #123", "Closes #123", "Related to #123", "Resolves #123"
+            const issuePattern = /(?:fix(?:es)?|close[sd]?|related to|resolves?)\s*#(\d+)/gi;
+            const matches = [...prBody.matchAll(issuePattern)];
+
+            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1])))];
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                // Check if issue exists and is open
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                if (issue.state === 'open') {
+                  // Add the pending-release label
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['pending-release']
+                  });
+
+                  // Add a comment
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `A fix for this issue has been merged in #${context.payload.pull_request.number}. It will be available in the next release.`
+                  });
+
+                  console.log(`Added pending-release label to issue #${issueNumber}`);
+                }
+              } catch (error) {
+                console.log(`Could not process issue #${issueNumber}: ${error.message}`);
+              }
+            }
+
+  # When a release is published, close all issues with "pending-release" label
+  close-released-issues:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issues with pending-release label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const releaseName = context.payload.release.name || context.payload.release.tag_name;
+
+            // Find all open issues with pending-release label
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'pending-release'
+            });
+
+            for (const issue of issues) {
+              try {
+                // Add a comment about the release
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `This issue has been fixed in ${releaseName}. 🎉`
+                });
+
+                // Remove the pending-release label
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: 'pending-release'
+                });
+
+                // Close the issue
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed'
+                });
+
+                console.log(`Closed issue #${issue.number}`);
+              } catch (error) {
+                console.log(`Could not close issue #${issue.number}: ${error.message}`);
+              }
+            }
+
+            console.log(`Closed ${issues.length} issues for release ${releaseName}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,15 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 ### Pull Request Descriptions
 - Include a `## Summary` section with bullet points
 - Include a `## Test plan` section with checklist items
-- Reference related issues with `Fixes #123` or `Closes #123`
+- Reference related issues with `Related to #123` (NOT `Fixes` or `Closes` - see below)
 - Do NOT include "Generated with Claude Code" or similar attribution lines
+
+### Issue Management
+Issues are closed only when the fix is published in a release, not when the PR is merged.
+
+- Use `Related to #123` in PR descriptions (not `Fixes #123` or `Closes #123`)
+- When a PR is merged, linked issues automatically get a `pending-release` label
+- When a release is published, all `pending-release` issues are automatically closed
 
 ### Releases
 Releases are created automatically by GitHub Actions when a version tag is pushed.


### PR DESCRIPTION
## Summary
- Create `pending-release` label for tracking issues with merged fixes
- Add GitHub Actions workflow that:
  - On PR merge: adds `pending-release` label to linked issues and comments
  - On release publish: closes all `pending-release` issues with a comment
- Update CLAUDE.md to document the workflow and use `Related to #X` instead of `Fixes #X`

## How it works
1. Developer creates PR with `Related to #30` in description
2. PR is merged → Issue #30 gets `pending-release` label + comment
3. Release is published → All `pending-release` issues are closed with release info

## Test plan
- [ ] Merge a PR with `Related to #X` in the body
- [ ] Verify issue gets `pending-release` label and comment
- [ ] Publish a release
- [ ] Verify issues are closed with release comment