### PR TITLE
fix: re-open auto-closed issues and add pending-release label

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -29,32 +29,41 @@ jobs:
 
             for (const issueNumber of issueNumbers) {
               try {
-                // Check if issue exists and is open
+                // Get issue state
                 const { data: issue } = await github.rest.issues.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber
                 });
 
-                if (issue.state === 'open') {
-                  // Add the pending-release label
-                  await github.rest.issues.addLabels({
+                // If GitHub auto-closed the issue (from "Fixes #X"), re-open it
+                if (issue.state === 'closed') {
+                  await github.rest.issues.update({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumber,
-                    labels: ['pending-release']
+                    state: 'open'
                   });
-
-                  // Add a comment
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    body: `A fix for this issue has been merged in #${context.payload.pull_request.number}. It will be available in the next release.`
-                  });
-
-                  console.log(`Added pending-release label to issue #${issueNumber}`);
+                  console.log(`Re-opened issue #${issueNumber} (was auto-closed by GitHub)`);
                 }
+
+                // Add the pending-release label
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['pending-release']
+                });
+
+                // Add a comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `A fix for this issue has been merged in #${context.payload.pull_request.number}. It will be available in the next release.`
+                });
+
+                console.log(`Added pending-release label to issue #${issueNumber}`);
               } catch (error) {
                 console.log(`Could not process issue #${issueNumber}: ${error.message}`);
               }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,14 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 ### Pull Request Descriptions
 - Include a `## Summary` section with bullet points
 - Include a `## Test plan` section with checklist items
-- Reference related issues with `Related to #123` (NOT `Fixes` or `Closes` - see below)
+- Reference related issues with `Fixes #123` or `Closes #123`
 - Do NOT include "Generated with Claude Code" or similar attribution lines
 
 ### Issue Management
 Issues are closed only when the fix is published in a release, not when the PR is merged.
 
-- Use `Related to #123` in PR descriptions (not `Fixes #123` or `Closes #123`)
-- When a PR is merged, linked issues automatically get a `pending-release` label
+- Use `Fixes #123` in PR descriptions to link the PR to the issue
+- When a PR is merged, GitHub auto-closes the issue but our workflow re-opens it with a `pending-release` label
 - When a release is published, all `pending-release` issues are automatically closed
 
 ### Releases


### PR DESCRIPTION
## Summary
- Update workflow to re-open issues that GitHub auto-closes when using `Fixes #X`
- This allows using `Fixes #X` syntax (which creates the PR-issue link) while still keeping issues open until release
- Update CLAUDE.md to document that `Fixes #X` can be used

## How it works now
1. PR uses `Fixes #30` in description → GitHub shows linked PR on issue
2. PR is merged → GitHub auto-closes issue #30
3. Our workflow runs → Re-opens issue #30, adds `pending-release` label + comment
4. Release is published → Issue #30 is closed with release info

## Test plan
- [ ] Create a PR with `Fixes #X` 
- [ ] Merge the PR
- [ ] Verify issue is re-opened with `pending-release` label