### PR TITLE
feat: add workflow to trigger website rebuild on release

### DIFF
--- a/.github/workflows/website-rebuild.yml
+++ b/.github/workflows/website-rebuild.yml
@@ -1,0 +1,16 @@
+name: Trigger Website Rebuild
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+          repository: DDEV-Manager/ddev-manager-site
+          event-type: release-published


### PR DESCRIPTION
## Summary
- Adds a new workflow that triggers a rebuild of the marketing website when a release is published
- Uses `repository_dispatch` to notify the `ddev-manager-site` repo

## Setup Required
Before this workflow will work, you need to:
1. Create a Personal Access Token (PAT) with `repo` scope
2. Add it as `WEBSITE_DEPLOY_TOKEN` secret in this repo's settings

## Test plan
- [ ] Create PAT and add as secret
- [ ] Publish a release and verify website rebuilds